### PR TITLE
add spriteDir option for next.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ And set up your paths in tsconfig.json
 
 ```json
 "paths": {
-  "~/icon-name": ["${iconsOutput}/name.d.ts", "${types}"]
+  "~/icon-name": ["${iconsOutput}/icon-name.d.ts", "${types}"]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ npx svg-icons-cli init
 #### Options
 
 - `-o, --output`: Where to store the Icon component. Defaults to `components/ui`
+- `--spriteDir`: Where to store the sprite svg. Defaults to output arg value
 - `-t, --types`: Where to store the default type definition file. Defaults to `types/icon-name.d.ts`
 
 > [!NOTE] > **Why not export `<Icon>` from this package?**

--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ And set up your paths in tsconfig.json
 
 ```json
 "paths": {
-  "~/icon-name": ["${iconsOutput}/icon-name.d.ts", "${types}"]
+  "~/icon-name": ["${iconsOutput}/name.d.ts", "${types}"]
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -170,7 +170,7 @@ icons build -i ${input} -o ${output}${shouldOptimize ? " --optimize" : ""}`,
   } else {
     mkdirSync(outputDir, { recursive: true });
     const spriteFilepath = path.join(outputDir, "sprite.svg");
-    const typeOutputFilepath = path.join(outputDir, "name.d.ts");
+    const typeOutputFilepath = path.join(outputDir, "icon-name.d.ts");
     const currentSprite = await fs
       .readFile(spriteFilepath, "utf8")
       .catch(() => "");
@@ -483,7 +483,7 @@ ${
 If you're using TypeScript, you'll need to configure your tsconfig.json to include the generated types:
 
 "paths": {
-  "~/icon-name": ["${iconsOutput}/name.d.ts", "${types}"]
+  "~/icon-name": ["${iconsOutput}/icon-name.d.ts", "${types}"]
 }`
     : ""
 }`);

--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ icons build -i ${input} -o ${output}${shouldOptimize ? " --optimize" : ""}`,
   } else {
     mkdirSync(outputDir, { recursive: true });
     const spriteFilepath = path.join(spriteDir, "sprite.svg");
-    const typeOutputFilepath = path.join(outputDir, "icon-name.d.ts");
+    const typeOutputFilepath = path.join(outputDir, "name.d.ts");
     const currentSprite = await fs
       .readFile(spriteFilepath, "utf8")
       .catch(() => "");
@@ -485,7 +485,7 @@ ${
 If you're using TypeScript, you'll need to configure your tsconfig.json to include the generated types:
 
 "paths": {
-  "~/icon-name": ["${iconsOutput}/icon-name.d.ts", "${types}"]
+  "~/icon-name": ["${iconsOutput}/name.d.ts", "${types}"]
 }`
     : ""
 }`);

--- a/index.js
+++ b/index.js
@@ -68,6 +68,7 @@ switch (command) {
   Options:
     -i, --input     The relative path where the source SVGs are stored
     -o, --output    Where the output sprite sheet and types should be stored
+    --spriteDir     Where the output sprite sheet should be stored (default to output param)
     --optimize      Optimize the output SVG using SVGO. 
     --help          Show help
   `,
@@ -143,6 +144,7 @@ async function build() {
   }
   if (isCancel(output)) process.exit(1);
   const outputDir = path.join(cwd, output);
+  const spriteDir = path.join(cwd, args.spriteDir ?? output);
   if (typeof args.optimize === "undefined") {
     const choseOptimize = await confirm({
       message: "Optimize the output SVG using SVGO?",
@@ -169,7 +171,7 @@ icons build -i ${input} -o ${output}${shouldOptimize ? " --optimize" : ""}`,
     process.exit(1);
   } else {
     mkdirSync(outputDir, { recursive: true });
-    const spriteFilepath = path.join(outputDir, "sprite.svg");
+    const spriteFilepath = path.join(spriteDir, "sprite.svg");
     const typeOutputFilepath = path.join(outputDir, "icon-name.d.ts");
     const currentSprite = await fs
       .readFile(spriteFilepath, "utf8")


### PR DESCRIPTION
This PR add an option to change `spriteDir` (useful for next.js public dir)
Closes #5 
